### PR TITLE
The issue with settextstyle() function solved

### DIFF
--- a/libbgi/src/text.cxx
+++ b/libbgi/src/text.cxx
@@ -173,7 +173,7 @@ static void set_font(WindowData* pWndData)
 
     // assign the fonts to each of the hdcs
     for ( int i = 0; i < MAX_PAGES; i++ )
-	SelectObject( pWndData->hDC[i], hFont );
+	DeleteObject(SelectObject( pWndData->hDC[i], hFont ));
 }
 
 


### PR DESCRIPTION
The issue with settextstyle() function solved

see this post: https://stackoverflow.com/questions/59544233/why-is-winbgi-function-settextstyle-occupying-memory-on-the-heap Signed-off-by: Master-COLLiDER